### PR TITLE
Make thieving overlay resizable and colorable

### DIFF
--- a/src/main/java/de0/coxthieving/CoxThievingDatabox.java
+++ b/src/main/java/de0/coxthieving/CoxThievingDatabox.java
@@ -10,17 +10,15 @@ import java.util.List;
 import javax.inject.Inject;
 
 import de0.coxthieving.CoxThievingPlugin.GrubCollection;
-import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.components.LayoutableRenderableEntity;
 import net.runelite.client.ui.overlay.components.LineComponent;
-import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
 
-public class CoxThievingDatabox extends Overlay {
+public class CoxThievingDatabox extends OverlayPanel {
 
   private CoxThievingPlugin plugin;
   private CoxThievingConfig config;
-  private PanelComponent panelComponent = new PanelComponent();
 
   @Inject
   public CoxThievingDatabox(CoxThievingPlugin plugin, CoxThievingConfig config) {
@@ -45,7 +43,6 @@ public class CoxThievingDatabox extends Overlay {
       sum_grubs += plugin.gc_others[i].num_with_grubs * config.grubRate() / 100;
 
     List<LayoutableRenderableEntity> elems = panelComponent.getChildren();
-    elems.clear();
     elems.add(TitleComponent.builder().color(Color.WHITE).text(
         (sum_grubs == plugin.num_grubs ? "Grub count: " : "Est. grub count: ")
             + sum_grubs)
@@ -57,7 +54,7 @@ public class CoxThievingDatabox extends Overlay {
     }
     if (myindex == plugin.gc_others_count)
       add_gc_line(elems, plugin.gc_local);
-    return this.panelComponent.render(graphics);
+    return super.render(graphics);
   }
 
   private void add_gc_line(List<LayoutableRenderableEntity> elems,


### PR DESCRIPTION
I got tired of having that brown overlay, so here is a PR to make the thieving room overlay resizable and adjust to runelite's overlay color config. Can see [this PR](https://github.com/runelite/runelite/pull/11188) from when it went from Overlay to OverlayPanel.

Tested this in-game and seems to work without any issues.