### PR TITLE
Add two new vanguard HP/reset threshold render locations.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.36.2'
+def runeLiteVersion = '1.8.18.4'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,7 +24,7 @@ dependencies {
 
 group = 'de0'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = '1.8'
+sourceCompatibility = '1.11'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/de0/coxvanguards/CoxVanguardsConfig.java
+++ b/src/main/java/de0/coxvanguards/CoxVanguardsConfig.java
@@ -44,4 +44,7 @@ public interface CoxVanguardsConfig extends Config {
     return Color.CYAN;
   }
 
+  @ConfigItem(position = 7, keyName = "numberLocation", name = "Number location", description = "Location to render each Vanguard's number")
+  default NumberLocationSetting getNumberLocation() { return NumberLocationSetting.DEFAULT_CENTER; }
+
 }

--- a/src/main/java/de0/coxvanguards/CoxVanguardsHighlight.java
+++ b/src/main/java/de0/coxvanguards/CoxVanguardsHighlight.java
@@ -74,7 +74,7 @@ public class CoxVanguardsHighlight extends Overlay {
 
       if (!goodToClear) {
         String str = goodToKill ? "*" + dist : Integer.toString(dist);
-        npctext(g, van, str, c);
+        npctext(g, van, str, c, config);
       }
     } else if (config.showHps()) {
       int hp = van.getHealthRatio();
@@ -82,17 +82,38 @@ public class CoxVanguardsHighlight extends Overlay {
         hp = last_hp;
       int hpPercent = hp * 100 / 30;
       String str = Integer.toString(hpPercent);
-      npctext(g, van, str, c);
+      npctext(g, van, str, c, config);
     }
   }
 
-  private void npctext(Graphics2D g, NPC npc, String str, Color c) {
-    Point point = npc.getCanvasTextLocation(g, str, npc.getLogicalHeight());
+  private void npctext(Graphics2D g, NPC npc, String str, Color c, CoxVanguardsConfig config) {
+    Point point = getVanguardTextLocation(g, npc, str, config);
     if (point == null)
       return;
-    point = new Point(point.getX(), point.getY() + 20);
     g.setFont(FontManager.getRunescapeBoldFont());
     OverlayUtil.renderTextLocation(g, point, str, c);
+  }
+
+  private Point getVanguardTextLocation(Graphics2D g, NPC npc, String str, CoxVanguardsConfig config) {
+    int zOffset, yOffset;
+    switch (config.getNumberLocation()) {
+      case BELOW_VANGUARD:
+        zOffset = 0;
+        yOffset = 24;
+        break;
+      case ABOVE_VANGUARD:
+        zOffset = npc.getLogicalHeight();
+        yOffset = -20;
+        break;
+      case DEFAULT_CENTER:
+      default:
+        zOffset = npc.getLogicalHeight();
+        yOffset = 20;
+    }
+    Point point = npc.getCanvasTextLocation(g, str, zOffset);
+    if (point == null)
+      return null;
+    return new Point(point.getX(), point.getY() + yOffset);
   }
 
 }

--- a/src/main/java/de0/coxvanguards/NumberLocationSetting.java
+++ b/src/main/java/de0/coxvanguards/NumberLocationSetting.java
@@ -1,0 +1,20 @@
+package de0.coxvanguards;
+
+public enum NumberLocationSetting {
+    DEFAULT_CENTER,
+    BELOW_VANGUARD,
+    ABOVE_VANGUARD;
+
+    @Override
+    public String toString() {
+        switch (this) {
+            case BELOW_VANGUARD:
+                return "Below";
+            case ABOVE_VANGUARD:
+                return "Above";
+            case DEFAULT_CENTER:
+            default:
+                return "Center (Default)";
+        }
+    }
+}


### PR DESCRIPTION
IMO it makes it a lot easier to see the reset threshold or current HP when there are lot of hitsplats on the NPC. Default behaviour is to draw it in the current location.

Below:
![image](https://user-images.githubusercontent.com/1549353/165891121-fd92a49e-b8d9-43e3-a281-d4399ad7139e.png)
Above:
![image](https://user-images.githubusercontent.com/1549353/165891101-8dc7aadb-c54e-4188-8691-b6e7dc2a2f8c.png)
