### PR TITLE
Add vangs aggro range option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@
 ![Example image](https://i.imgur.com/sLfV7bA.png)
 
 ## Changelog
+#### 13/08/2025
+- Fix burn damage not being tracked at Vanguards. @Koekenpann
+- Add melee aggro range at Vanguards. @vikke1234
+
+#### 13/07/2024
+- Remove thieving check success rate.
+
 #### 30/04/2024
 - Fixed Vanguards HP in scaled solo raids.
 - Fixed floor end timer bug.

--- a/src/main/java/de0/coxvanguards/CoxVanguardsConfig.java
+++ b/src/main/java/de0/coxvanguards/CoxVanguardsConfig.java
@@ -24,22 +24,32 @@ public interface CoxVanguardsConfig extends Config {
     return true;
   }
 
-  @ConfigItem(position = 3, keyName = "showDatabox", name = "Show HPs in a databox", description = "Show Vanguard HPs databox")
+  @ConfigItem(position = 3, keyName = "wanderRange", name ="Show melee wander range", description = "Show how far you need to go before losing agro from melee")
+  default boolean wanderRange() {
+    return false;
+  }
+
+  @ConfigItem(position = 4, keyName = "showDatabox", name = "Show HPs in a databox", description = "Show Vanguard HPs databox")
   default boolean showDatabox() {
     return false;
   }
 
-  @ConfigItem(position = 4, keyName = "meleeColor", name = "Melee Vanguard color", description = "Highlight color for melee Vanguard")
+  @ConfigItem(position = 5, keyName = "meleeColor", name = "Melee Vanguard color", description = "Highlight color for melee Vanguard")
   default Color getMeleeColor() {
     return Color.RED;
   }
 
-  @ConfigItem(position = 5, keyName = "rangeColor", name = "Range Vanguard color", description = "Highlight color for range Vanguard")
+  @ConfigItem(position = 5, keyName = "wanderColor", name = "Melee Vanguard wander color", description = "Highlight color for melee Vanguard wander range")
+  default Color getMeleeWanderColor() {
+    return new Color(0xC35364);
+  }
+
+  @ConfigItem(position = 6, keyName = "rangeColor", name = "Range Vanguard color", description = "Highlight color for range Vanguard")
   default Color getRangeColor() {
     return Color.GREEN;
   }
 
-  @ConfigItem(position = 6, keyName = "mageColor", name = "Mage Vanguard color", description = "Highlight color for mage Vanguard")
+  @ConfigItem(position = 7, keyName = "mageColor", name = "Mage Vanguard color", description = "Highlight color for mage Vanguard")
   default Color getMageColor() {
     return Color.CYAN;
   }

--- a/src/main/java/de0/coxvanguards/CoxVanguardsConfig.java
+++ b/src/main/java/de0/coxvanguards/CoxVanguardsConfig.java
@@ -24,34 +24,34 @@ public interface CoxVanguardsConfig extends Config {
     return true;
   }
 
-  @ConfigItem(position = 3, keyName = "wanderRange", name ="Show melee wander range", description = "Show how far you need to go before losing agro from melee")
-  default boolean wanderRange() {
-    return false;
-  }
-
-  @ConfigItem(position = 4, keyName = "showDatabox", name = "Show HPs in a databox", description = "Show Vanguard HPs databox")
+  @ConfigItem(position = 3, keyName = "showDatabox", name = "Show HPs in a databox", description = "Show Vanguard HPs databox")
   default boolean showDatabox() {
     return false;
   }
 
-  @ConfigItem(position = 5, keyName = "meleeColor", name = "Melee Vanguard color", description = "Highlight color for melee Vanguard")
+  @ConfigItem(position = 4, keyName = "meleeColor", name = "Melee Vanguard color", description = "Highlight color for melee Vanguard")
   default Color getMeleeColor() {
     return Color.RED;
   }
 
-  @ConfigItem(position = 5, keyName = "wanderColor", name = "Melee Vanguard wander color", description = "Highlight color for melee Vanguard wander range")
-  default Color getMeleeWanderColor() {
-    return new Color(0xC35364);
-  }
-
-  @ConfigItem(position = 6, keyName = "rangeColor", name = "Range Vanguard color", description = "Highlight color for range Vanguard")
+  @ConfigItem(position = 5, keyName = "rangeColor", name = "Range Vanguard color", description = "Highlight color for range Vanguard")
   default Color getRangeColor() {
     return Color.GREEN;
   }
 
-  @ConfigItem(position = 7, keyName = "mageColor", name = "Mage Vanguard color", description = "Highlight color for mage Vanguard")
+  @ConfigItem(position = 6, keyName = "mageColor", name = "Mage Vanguard color", description = "Highlight color for mage Vanguard")
   default Color getMageColor() {
     return Color.CYAN;
+  }
+
+  @ConfigItem(position = 7, keyName = "wanderRange", name ="Show melee wander range", description = "Show how far you need to go before losing agro from melee")
+  default boolean wanderRange() {
+    return false;
+  }
+
+  @ConfigItem(position = 8, keyName = "wanderColor", name = "Melee Vanguard wander color", description = "Highlight color for melee Vanguard wander range")
+  default Color getMeleeWanderColor() {
+    return new Color(0xC35364);
   }
 
 }

--- a/src/main/java/de0/coxvanguards/CoxVanguardsHighlight.java
+++ b/src/main/java/de0/coxvanguards/CoxVanguardsHighlight.java
@@ -1,14 +1,15 @@
 package de0.coxvanguards;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics2D;
-import java.awt.Shape;
+import java.awt.*;
+import java.util.Objects;
 
 import javax.inject.Inject;
 
-import net.runelite.api.NPC;
+import lombok.NonNull;
+import net.runelite.api.*;
 import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -20,14 +21,17 @@ import static java.lang.Math.min;
 
 public class CoxVanguardsHighlight extends Overlay {
 
+  @Inject
+  private Client client;
+
+  @Inject
   private CoxVanguardsPlugin plugin;
+
+  @Inject
   private CoxVanguardsConfig config;
 
   @Inject
-  public CoxVanguardsHighlight(CoxVanguardsPlugin plugin, CoxVanguardsConfig config) {
-    super(plugin);
-    this.plugin = plugin;
-    this.config = config;
+  protected void init() {
     setPosition(OverlayPosition.DYNAMIC);
     setLayer(OverlayLayer.ABOVE_SCENE);
   }
@@ -43,7 +47,59 @@ public class CoxVanguardsHighlight extends Overlay {
     if (plugin.mage != null)
       renderVanguard(plugin.mage, plugin.maghp, plugin.maghp_fine, g,
           config.getMageColor());
+    if (plugin.meleeSpawn != null && config.wanderRange()) {
+      renderBox(g, plugin.meleeSpawn);
+    }
     return null;
+  }
+
+  private Point getTileCorner(Client client, WorldView vw, WorldPoint wp, int plane, int cornerIndex)
+  {
+    LocalPoint lp = LocalPoint.fromWorld(vw, wp);
+    if (lp == null)
+    {
+      return null;
+    }
+
+    Polygon poly = Perspective.getCanvasTilePoly(client, lp, plane);
+    if (poly == null || poly.npoints < 4)
+    {
+      return null;
+    }
+
+    // Indices: 0 = TL, 1 = TR, 2 = BR, 3 = BL
+    return new Point(poly.xpoints[cornerIndex], poly.ypoints[cornerIndex]);
+  }
+
+  private void renderBox(Graphics2D g, @NonNull WorldPoint spawn) {
+    WorldView vw = client.getWorldView(-1);
+    int plane = vw.getPlane();
+    int radius = 9;
+
+    // Define the 4 corner tiles of the square
+    WorldPoint topLeft = spawn.dx(-radius).dy(-radius);
+    WorldPoint topRight = spawn.dx(radius).dy(-radius);
+    WorldPoint bottomRight = spawn.dx(radius).dy(radius);
+    WorldPoint bottomLeft = spawn.dx(-radius).dy(radius);
+
+    // Get the relevant corners of each tile (see note below)
+    Point tl = getTileCorner(client, vw, topLeft, plane, 0); // Top-left
+    Point tr = getTileCorner(client, vw, topRight, plane, 1); // Top-right
+    Point br = getTileCorner(client, vw, bottomRight, plane, 2); // Bottom-right
+    Point bl = getTileCorner(client, vw, bottomLeft, plane, 3); // Bottom-left
+
+    if (tl != null && tr != null && br != null && bl != null)
+    {
+      Polygon outline = new Polygon();
+      outline.addPoint(tl.getX(), tl.getY());
+      outline.addPoint(tr.getX(), tr.getY());
+      outline.addPoint(br.getX(), br.getY());
+      outline.addPoint(bl.getX(), bl.getY());
+
+      g.setColor(config.getMeleeWanderColor());
+      g.drawPolygon(outline);
+      g.drawPolygon(Perspective.getCanvasTilePoly(client, LocalPoint.fromWorld(vw, spawn)));
+    }
   }
 
   private void renderVanguard(NPC van, int last_hp, int hp_fine, Graphics2D g,

--- a/src/main/java/de0/coxvanguards/CoxVanguardsHighlight.java
+++ b/src/main/java/de0/coxvanguards/CoxVanguardsHighlight.java
@@ -1,7 +1,6 @@
 package de0.coxvanguards;
 
 import java.awt.*;
-import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -103,7 +102,7 @@ public class CoxVanguardsHighlight extends Overlay {
   }
 
   private void renderVanguard(NPC van, int last_hp, int hp_fine, Graphics2D g,
-      Color c) {
+                              Color c) {
     if (van.getId() < 7525 || van.getId() > 7529)
       return;
 

--- a/src/main/java/de0/coxvanguards/CoxVanguardsPlugin.java
+++ b/src/main/java/de0/coxvanguards/CoxVanguardsPlugin.java
@@ -12,6 +12,8 @@ import net.runelite.api.events.HitsplatApplied;
 import net.runelite.api.events.NpcChanged;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
+import net.runelite.api.gameval.NpcID;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
@@ -85,9 +87,9 @@ public class CoxVanguardsPlugin extends Plugin {
   @Subscribe
   public void onNpcSpawned(NpcSpawned e) {
     NPC npc = e.getNpc();
-    if (melee == null && npc.getId() == 7527)
+    if (melee == null && npc.getId() == NpcID.RAIDS_VANGUARD_MELEE)
       melee = npc;
-    else if (range == null && npc.getId() == 7528)
+    else if (range == null && npc.getId() == NpcID.RAIDS_VANGUARD_RANGED)
       range = npc;
     else if (mage == null && npc.getId() == 7529)
       mage = npc;
@@ -96,13 +98,15 @@ public class CoxVanguardsPlugin extends Plugin {
   @Subscribe
   public void onNpcChanged(NpcChanged e) {
     NPC npc = e.getNpc();
-    if (npc.getId() == 7527 && melee == null)
+    if (npc.getId() == NpcID.RAIDS_VANGUARD_MELEE && melee == null) {
       melee = npc;
     else if (npc.getId() == 7528 && range == null)
+      WorldPoint coords = npc.getWorldLocation();
+    } else if (npc.getId() == NpcID.RAIDS_VANGUARD_RANGED && range == null)
       range = npc;
-    else if (npc.getId() == 7529 && mage == null)
+    else if (npc.getId() == NpcID.RAIDS_VANGUARD_RANGED && mage == null)
       mage = npc;
-    else if (npc.getId() == 7526) {
+    else if (npc.getId() == NpcID.RAIDS_VANGUARD_WALKING) {
       if (npc == melee) {
         melhp_fine = Math.min(solo_base_hp, melhp_fine + 1);
       } else if (npc == range) {
@@ -116,9 +120,10 @@ public class CoxVanguardsPlugin extends Plugin {
   @Subscribe
   public void onNpcDespawned(NpcDespawned e) {
     NPC npc = e.getNpc();
-    if (npc == melee)
+    if (npc == melee) {
       melee = null;
     else if (npc == range)
+    } else if (npc == range)
       range = null;
     else if (npc == mage)
       mage = null;
@@ -155,13 +160,13 @@ public class CoxVanguardsPlugin extends Plugin {
   }
 
   boolean isSolo() {
-    return client.getVarbitValue(9540) == 1;
+    return client.getVarbitValue(VarbitID.RAIDS_CLIENT_PARTYSIZE_SCALED) == 1;
   }
 
   int getSoloBaseHp() {
     int base_hp = 180;
     base_hp = base_hp * client.getLocalPlayer().getCombatLevel() / 126;
-    boolean cm = client.getVarbitValue(6385) != 0;
+    boolean cm = client.getVarbitValue(VarbitID.RAIDS_CHALLENGE_MODE) != 0;
     if (cm)
       base_hp = base_hp * 3 / 2;
 

--- a/src/main/java/de0/coxvanguards/CoxVanguardsPlugin.java
+++ b/src/main/java/de0/coxvanguards/CoxVanguardsPlugin.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.HitsplatID;
 import net.runelite.api.NPC;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.HitsplatApplied;
@@ -38,6 +39,8 @@ public class CoxVanguardsPlugin extends Plugin {
   private boolean in_raid;
 
   int solo_base_hp;
+
+  WorldPoint meleeSpawn;
 
   NPC melee, range, mage;
   int melhp, rnghp, maghp;
@@ -87,24 +90,26 @@ public class CoxVanguardsPlugin extends Plugin {
   @Subscribe
   public void onNpcSpawned(NpcSpawned e) {
     NPC npc = e.getNpc();
-    if (melee == null && npc.getId() == NpcID.RAIDS_VANGUARD_MELEE)
+    if (melee == null && npc.getId() == NpcID.RAIDS_VANGUARD_MELEE) {
       melee = npc;
-    else if (range == null && npc.getId() == NpcID.RAIDS_VANGUARD_RANGED)
+    } else if (range == null && npc.getId() == NpcID.RAIDS_VANGUARD_RANGED)
       range = npc;
-    else if (mage == null && npc.getId() == 7529)
+    else if (mage == null && npc.getId() == NpcID.RAIDS_VANGUARD_MAGIC)
       mage = npc;
   }
 
   @Subscribe
   public void onNpcChanged(NpcChanged e) {
     NPC npc = e.getNpc();
-    if (npc.getId() == NpcID.RAIDS_VANGUARD_MELEE && melee == null) {
-      melee = npc;
-    else if (npc.getId() == 7528 && range == null)
-      WorldPoint coords = npc.getWorldLocation();
+    if (npc.getId() == NpcID.RAIDS_VANGUARD_MELEE) {
+      if (melee == null)
+        melee = npc;
+      // Only set the melee location on digs, can have been dragged if late otherwise.
+      if (meleeSpawn == null)
+        meleeSpawn = npc.getWorldLocation().dx(1).dy(1);
     } else if (npc.getId() == NpcID.RAIDS_VANGUARD_RANGED && range == null)
       range = npc;
-    else if (npc.getId() == NpcID.RAIDS_VANGUARD_RANGED && mage == null)
+    else if (npc.getId() == NpcID.RAIDS_VANGUARD_MAGIC && mage == null)
       mage = npc;
     else if (npc.getId() == NpcID.RAIDS_VANGUARD_WALKING) {
       if (npc == melee) {
@@ -122,7 +127,7 @@ public class CoxVanguardsPlugin extends Plugin {
     NPC npc = e.getNpc();
     if (npc == melee) {
       melee = null;
-    else if (npc == range)
+      meleeSpawn = null;
     } else if (npc == range)
       range = null;
     else if (npc == mage)


### PR DESCRIPTION
<img width="1179" height="296" alt="image" src="https://github.com/user-attachments/assets/efc357f6-71af-4235-ad71-52aadd524486" />
Add aggro range that matches this image, enabled currently for all scales. You need to be roughly first tick in the room for it to work properly, it hasn't been disabled though in non-solos as it's still a decent chance for it to be correct.