### PR TITLE
COX Vanguards: Add config options for hp overlay text size and text offset

### DIFF
--- a/src/main/java/de0/coxvanguards/CoxVanguardsConfig.java
+++ b/src/main/java/de0/coxvanguards/CoxVanguardsConfig.java
@@ -5,6 +5,7 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
 
 @ConfigGroup("vanguards")
 public interface CoxVanguardsConfig extends Config {
@@ -14,42 +15,54 @@ public interface CoxVanguardsConfig extends Config {
     return true;
   }
 
-  @ConfigItem(position = 1, keyName = "showDmgToReset", name = "Show dmg to reset (solo)", description = "Show Vanguard dmg amount till reset")
+  @Range(min = 8, max = 32)
+  @ConfigItem(position = 1, keyName = "fontSize", name = "HP text font size", description = "Size of the HP/reset text font")
+  default int fontSize() {
+    return 16;
+  }
+
+  @Range(min = -100, max = 100)
+  @ConfigItem(position = 2, keyName = "heightOffset", name = "HP text height offset", description = "Shifts the HP/reset text up (positive) or down (negative) relative to its default position")
+  default int heightOffset() {
+    return 0;
+  }
+
+  @ConfigItem(position = 3, keyName = "showDmgToReset", name = "Show dmg to reset (solo)", description = "Show Vanguard dmg amount till reset")
   default boolean showDmgToReset() {
     return true;
   }
 
-  @ConfigItem(position = 2, keyName = "highlight", name = "Highlight", description = "Highlights Vanguards of their respective color.")
+  @ConfigItem(position = 4, keyName = "highlight", name = "Highlight", description = "Highlights Vanguards of their respective color.")
   default boolean highlight() {
     return true;
   }
 
-  @ConfigItem(position = 3, keyName = "showDatabox", name = "Show HPs in a databox", description = "Show Vanguard HPs databox")
+  @ConfigItem(position = 5, keyName = "showDatabox", name = "Show HPs in a databox", description = "Show Vanguard HPs databox")
   default boolean showDatabox() {
     return false;
   }
 
-  @ConfigItem(position = 4, keyName = "meleeColor", name = "Melee Vanguard color", description = "Highlight color for melee Vanguard")
+  @ConfigItem(position = 6, keyName = "meleeColor", name = "Melee Vanguard color", description = "Highlight color for melee Vanguard")
   default Color getMeleeColor() {
     return Color.RED;
   }
 
-  @ConfigItem(position = 5, keyName = "rangeColor", name = "Range Vanguard color", description = "Highlight color for range Vanguard")
+  @ConfigItem(position = 7, keyName = "rangeColor", name = "Range Vanguard color", description = "Highlight color for range Vanguard")
   default Color getRangeColor() {
     return Color.GREEN;
   }
 
-  @ConfigItem(position = 6, keyName = "mageColor", name = "Mage Vanguard color", description = "Highlight color for mage Vanguard")
+  @ConfigItem(position = 8, keyName = "mageColor", name = "Mage Vanguard color", description = "Highlight color for mage Vanguard")
   default Color getMageColor() {
     return Color.CYAN;
   }
 
-  @ConfigItem(position = 7, keyName = "wanderRange", name ="Show melee wander range", description = "Show how far you need to go before losing agro from melee")
+  @ConfigItem(position = 9, keyName = "wanderRange", name ="Show melee wander range", description = "Show how far you need to go before losing agro from melee")
   default boolean wanderRange() {
     return false;
   }
 
-  @ConfigItem(position = 8, keyName = "wanderColor", name = "Melee Vanguard wander color", description = "Highlight color for melee Vanguard wander range")
+  @ConfigItem(position = 10, keyName = "wanderColor", name = "Melee Vanguard wander color", description = "Highlight color for melee Vanguard wander range")
   default Color getMeleeWanderColor() {
     return new Color(0xC35364);
   }

--- a/src/main/java/de0/coxvanguards/CoxVanguardsHighlight.java
+++ b/src/main/java/de0/coxvanguards/CoxVanguardsHighlight.java
@@ -145,8 +145,8 @@ public class CoxVanguardsHighlight extends Overlay {
     Point point = npc.getCanvasTextLocation(g, str, npc.getLogicalHeight());
     if (point == null)
       return;
-    point = new Point(point.getX(), point.getY() + 20);
-    g.setFont(FontManager.getRunescapeBoldFont());
+    point = new Point(point.getX(), point.getY() + 20 - config.heightOffset());
+    g.setFont(FontManager.getRunescapeBoldFont().deriveFont((float) config.fontSize()));
     OverlayUtil.renderTextLocation(g, point, str, c);
   }
 


### PR DESCRIPTION
The default hp overlay has a pretty annoying problem where it becomes not visible / hard to see when there are hitsplats on the mob (wich is like always). 

<img width="474" height="291" alt="image" src="https://github.com/user-attachments/assets/645408c2-b48e-4a79-a592-a6c8beca2e7d" />

<img width="473" height="242" alt="image" src="https://github.com/user-attachments/assets/28bc62c8-6bb6-4540-800a-8326d41cdc37" />

<img width="468" height="252" alt="image" src="https://github.com/user-attachments/assets/51c972d3-9a0e-4eca-a2e8-16afbd10baa1" />





<img width="242" height="616" alt="image" src="https://github.com/user-attachments/assets/b20de398-da85-42c7-a5c6-ea42ed55224c" />
